### PR TITLE
use の指定でモジュールと関数の指定を省略できるようにした

### DIFF
--- a/lib/ex_doukaku/test_runner.ex
+++ b/lib/ex_doukaku/test_runner.ex
@@ -1,6 +1,11 @@
 defmodule ExDoukaku.TestRunner do
   defmacro __using__(opts) do
-    [module, fun] = get_in(opts, [:solver])
+    [module, fun] =
+      case get_in(opts, [:solver]) do
+        nil -> [__MODULE__, :solve]
+        [m, f] -> [m, f]
+        f -> [__MODULE__, f]
+      end
 
     quote do
       @before_compile ExDoukaku.TestRunner

--- a/lib/ex_doukaku/test_runner.ex
+++ b/lib/ex_doukaku/test_runner.ex
@@ -1,17 +1,24 @@
 defmodule ExDoukaku.TestRunner do
   defmacro __using__(opts) do
-    [module, fun] =
-      case get_in(opts, [:solver]) do
-        nil -> [__MODULE__, :solve]
-        [m, f] -> [m, f]
-        f -> [__MODULE__, f]
-      end
-
     quote do
-      @before_compile ExDoukaku.TestRunner
       import ExDoukaku.TestRunner, only: [c_styled_test_data: 1]
 
+      @before_compile ExDoukaku.TestRunner
       @c_styled_test_data []
+
+      case get_in(unquote(opts), [:solver]) do
+        nil ->
+          @module __MODULE__
+          @fun :solve
+
+        [m, f] ->
+          @module m
+          @fun f
+
+        f ->
+          @module __MODULE__
+          @fun f
+      end
 
       def run(options \\ []) do
         inspector = Keyword.get(options, :inspector, & &1)
@@ -23,7 +30,7 @@ defmodule ExDoukaku.TestRunner do
       end
 
       def test(test_data) do
-        ExDoukaku.test(test_data, unquote(module), unquote(fun))
+        ExDoukaku.test(test_data, @module, @fun)
       end
     end
   end


### PR DESCRIPTION
次のように指定できるようにした。

```elixir
# モジュールを省略
use ExDoukaku.TestRunner, solver: :fun

# これと同じ
use ExDoukaku.TestRunner, solver: [__MODULE__, :fun]
```

```elixir
# モジュールと関数を省略
use ExDoukaku.TestRunner

# これと同じ
use ExDoukaku.TestRunner, solver: [__MODULE__, :solve]
```
