### PR TITLE
test runner モジュールを判定する関数の冗長な述語を削除した

### DIFF
--- a/lib/mix/tasks/doukaku.test.ex
+++ b/lib/mix/tasks/doukaku.test.ex
@@ -64,7 +64,7 @@ defmodule Mix.Tasks.Doukaku.Test do
     end
   end
 
-  defp module_enabled?(module), do: Code.ensure_loaded?(module) && function_exported?(module, :__info__, 1) && {:run, 1} in apply(module, :__info__, [:functions])
+  defp module_enabled?(module), do: Code.ensure_loaded?(module) && function_exported?(module, :run, 1)
 
   defp run_test(runner_module, options) do
     options = put_in(options[:inspector], &ExDoukaku.inspect_result/1)


### PR DESCRIPTION
`Code.module_enabled?/1` を実行することでモジュールがロードされ、モジュールが関数 `run/1` を持っているかを `function_exported?/3` で判定できるようになる。